### PR TITLE
Update BarcodeCaptureFragment.java

### DIFF
--- a/mvbarcodereader/src/main/java/devliving/online/mvbarcodereader/BarcodeCaptureFragment.java
+++ b/mvbarcodereader/src/main/java/devliving/online/mvbarcodereader/BarcodeCaptureFragment.java
@@ -565,7 +565,9 @@ public class BarcodeCaptureFragment extends Fragment implements View.OnTouchList
          */
         @Override
         public void onScaleEnd(ScaleGestureDetector detector) {
-            mCameraSource.doZoom(detector.getScaleFactor());
+            if(mCameraSource != null){
+                mCameraSource.doZoom(detector.getScaleFactor());
+            }
         }
     }
 


### PR DESCRIPTION
When user denied the permission then there will be a crash because mCameraSource is null.